### PR TITLE
Various UI adjustments

### DIFF
--- a/views/application.coffee
+++ b/views/application.coffee
@@ -20,6 +20,8 @@ renderLegislators = (response) ->
   else
     $(".signup").attr("data-state", "loaded")
 
+  $("html, body").animate {scrollTop: $(document).height()} # deal with vertical SRE issues in a better way later
+
 $(document).ready ->
   $(".legislators").on "change", ".select-legislator input[type='checkbox']", ->
     $(this).closest(".select-legislator").toggleClass "selected", $(this).prop("checked")

--- a/views/application.scss
+++ b/views/application.scss
@@ -188,7 +188,7 @@ a {
     .legislators {
       margin-bottom: 1.25em;
       list-style: none;
-      padding-bottom: 0;
+      padding: 1em 1em 0;
       overflow: hidden;
 
       li {

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Congress Track</title>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <!-- <meta name="viewport" content="initial-scale=1.0, user-scalable=no"> -->
     <meta charset="utf-8">
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="/application.css">


### PR DESCRIPTION
- Corrected legislators list element padding
- Until the layout is reworked for more graceful handling of
  vertical SRE consumption, loading legislators now smoothly
  scrolls to the bottom
- Commented out no-scale for mobile(will do proper small screen
  friendlienss later)
